### PR TITLE
Tactical build fix

### DIFF
--- a/reports/hourlyusage/Dockerfile
+++ b/reports/hourlyusage/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY requirements.txt ./
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --break-system-packages -r requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
### Change description ###
Tactical build fix to continue using `pip` for package installation