### PR TITLE
Adding comments to the MI group access due to insufficient perms for service connection

### DIFF
--- a/components/versionreporting/06-mi-access.tf
+++ b/components/versionreporting/06-mi-access.tf
@@ -3,7 +3,10 @@ data "azuread_group" "reader_access_group" {
   security_enabled = true
 }
 
-resource "azuread_group_member" "group_membership" {
-  group_object_id  = data.azuread_group.reader_access_group.id
-  member_object_id = module.version_reporter_key_vault.managed_identity_objectid[0]
-}
+# Service connection does not have enough access to grant this via automation
+# The addition of the MI to the group has been completed manually and the code commented here to limit failures
+# The code is being left here for reference and understand if required in future
+# resource "azuread_group_member" "group_membership" {
+#   group_object_id  = data.azuread_group.reader_access_group.id
+#   member_object_id = module.version_reporter_key_vault.managed_identity_objectid[0]
+# }


### PR DESCRIPTION
### Change description ###
Adding comments to the MI group access due to insufficient perms for service connection
