### PR TITLE
DTSPO-18384: Add role assignments to all MIS for cosmos

### DIFF
--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -41,14 +41,14 @@ data "azurerm_cosmosdb_account" "version_reporter" {
   resource_group_name = "cft-platform-version-reporter-ptl-rg"
 }
 
-resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
-  resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
-  account_name        = data.azurerm_cosmosdb_account.version_reporter.name
-  # Cosmos DB Built-in Data Contributor
-  role_definition_id = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
-  principal_id       = azurerm_user_assigned_identity.managed_identity.principal_id
-  scope              = data.azurerm_cosmosdb_account.version_reporter.id
-}
+# resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
+#   resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
+#   account_name        = data.azurerm_cosmosdb_account.version_reporter.name
+#   # Cosmos DB Built-in Data Contributor
+#   role_definition_id = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+#   principal_id       = azurerm_user_assigned_identity.managed_identity.principal_id
+#   scope              = data.azurerm_cosmosdb_account.version_reporter.id
+# }
 
 # Service connection does not have enough access to grant this via automation
 # The addition of the MI to the group has been completed manually and the code commented here to limit failures

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -41,14 +41,14 @@ data "azurerm_cosmosdb_account" "version_reporter" {
   resource_group_name = "cft-platform-version-reporter-ptl-rg"
 }
 
-# resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
-#   resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
-#   account_name        = data.azurerm_cosmosdb_account.version_reporter.name
-#   # Cosmos DB Built-in Data Contributor
-#   role_definition_id = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
-#   principal_id       = azurerm_user_assigned_identity.managed_identity.principal_id
-#   scope              = data.azurerm_cosmosdb_account.version_reporter.id
-# }
+resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
+  resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.version_reporter.name
+  # Cosmos DB Built-in Data Contributor
+  role_definition_id = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id       = azurerm_user_assigned_identity.managed_identity.principal_id
+  scope              = data.azurerm_cosmosdb_account.version_reporter.id
+}
 
 # Service connection does not have enough access to grant this via automation
 # The addition of the MI to the group has been completed manually and the code commented here to limit failures

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -35,6 +35,21 @@ resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
   ]
 }
 
+data "azurerm_cosmosdb_account" "version_reporter" {
+  provider            = azurerm.ptl
+  name                = "version-reporter-ptl-cosmos"
+  resource_group_name = "cft-platform-version-reporter-ptl-rg"
+}
+
+resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
+  resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.version_reporter.name
+  # Cosmos DB Built-in Data Contributor
+  role_definition_id = "${azurerm_cosmosdb_account.cosmosdb.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id       = azurerm_user_assigned_identity.managed_identity.principal_id
+  scope              = data.azurerm_cosmosdb_account.version_reporter.id
+}
+
 # Service connection does not have enough access to grant this via automation
 # The addition of the MI to the group has been completed manually and the code commented here to limit failures
 # The code is being left here for reference and understand if required in future

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -45,7 +45,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
   resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
   account_name        = data.azurerm_cosmosdb_account.version_reporter.name
   # Cosmos DB Built-in Data Contributor
-  role_definition_id = "${azurerm_cosmosdb_account.cosmosdb.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  role_definition_id = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
   principal_id       = azurerm_user_assigned_identity.managed_identity.principal_id
   scope              = data.azurerm_cosmosdb_account.version_reporter.id
 }

--- a/components/versionreporting/00-init.tf
+++ b/components/versionreporting/00-init.tf
@@ -16,11 +16,11 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {
+}
+
 provider "azurerm" {
   alias           = "ptlsbox"
   subscription_id = var.ptlsbox_subscription
   features {}
 }
-
-# provider "azuread" {
-# }

--- a/components/versionreporting/05-cosmosdb.tf
+++ b/components/versionreporting/05-cosmosdb.tf
@@ -53,3 +53,23 @@ resource "azurerm_cosmosdb_sql_container" "this" {
     }
   }
 }
+
+data "azuread_service_principals" "pipeline" {
+  display_names = [
+    "DTS Bootstrap (sub:dcd-cftapps-sbox)",
+    "DTS Bootstrap (sub:dcd-cftapps-dev)",
+    "DTS Bootstrap (sub:dcd-cftapps-demo)",
+    "DTS Bootstrap (sub:dcd-cftapps-stg)",
+    "DTS Bootstrap (sub:dcd-cftapps-test)",
+    "DTS Bootstrap (sub:dcd-cftapps-prod)",
+    "DTS Bootstrap (sub:dts-cftsbox-intsvc)",
+    "DTS Bootstrap (sub:dts-cftptl-intsvc)"
+  ]
+}
+
+resource "azurerm_role_assignment" "rbac_admin" {
+  for_each             = { for sp in data.azuread_service_principals.example.service_principals : sp.object_id => sp }
+  role_definition_name = "Role Based Access Control Administrator"
+  principal_id         = each.key
+  scope                = azurerm_cosmosdb_account.this.id
+}

--- a/components/versionreporting/05-cosmosdb.tf
+++ b/components/versionreporting/05-cosmosdb.tf
@@ -58,6 +58,7 @@ data "azuread_service_principals" "pipeline" {
   display_names = [
     "DTS Bootstrap (sub:dcd-cftapps-sbox)",
     "DTS Bootstrap (sub:dcd-cftapps-dev)",
+    "DTS Bootstrap (sub:dcd-cftapps-ithc)",
     "DTS Bootstrap (sub:dcd-cftapps-demo)",
     "DTS Bootstrap (sub:dcd-cftapps-stg)",
     "DTS Bootstrap (sub:dcd-cftapps-test)",

--- a/components/versionreporting/05-cosmosdb.tf
+++ b/components/versionreporting/05-cosmosdb.tf
@@ -68,7 +68,7 @@ data "azuread_service_principals" "pipeline" {
 }
 
 resource "azurerm_role_assignment" "rbac_admin" {
-  for_each             = { for sp in data.azuread_service_principals.example.service_principals : sp.object_id => sp }
+  for_each             = { for sp in data.azuread_service_principals.pipeline.service_principals : sp.object_id => sp }
   role_definition_name = "Role Based Access Control Administrator"
   principal_id         = each.key
   scope                = azurerm_cosmosdb_account.this.id

--- a/reports/renovate/save-to-cosmos.py
+++ b/reports/renovate/save-to-cosmos.py
@@ -7,7 +7,6 @@ from azure.cosmos import CosmosClient, exceptions
 
 # Environment variables passed in via sds flux configuration
 endpoint = os.environ.get("COSMOS_DB_URI", None)
-key = os.environ.get("COSMOS_KEY", None)
 database = os.environ.get("COSMOS_DB_NAME", "reports")
 container_name = os.environ.get("COSMOS_DB_CONTAINER", "renovate")
 max_days_away = int(os.environ.get("MAX_DAYS_AWAY", 3))
@@ -88,11 +87,12 @@ documents = json.loads(sys.argv[1])
 
 # Establish connection to cosmos db
 print("Connection to database...")
-client = CosmosClient(endpoint, key)
+client = CosmosClient(endpoint, credential=credential)
 
 # Save documents to cosmos db
 try:
     print("Setting of connectivity to database")
+    credential = DefaultAzureCredential()
     database = client.get_database_client(database)
     db_container = database.get_container_client(container_name)
 

--- a/reports/renovate/save-to-cosmos.py
+++ b/reports/renovate/save-to-cosmos.py
@@ -85,14 +85,14 @@ def get_formatted_datetime(strformat="%Y-%m-%d %H:%M:%S"):
 # Document passing in as arguments from bash script
 documents = json.loads(sys.argv[1])
 
-# Establish connection to cosmos db
-print("Connection to database...")
-client = CosmosClient(endpoint, credential=credential)
 
 # Save documents to cosmos db
 try:
     print("Setting of connectivity to database")
     credential = DefaultAzureCredential()
+    # Establish connection to cosmos db
+    print("Connection to database...")
+    client = CosmosClient(endpoint, credential=credential)
     database = client.get_database_client(database)
     db_container = database.get_container_client(container_name)
 


### PR DESCRIPTION
Adds builtin cosmos data contributor roles to all our MIs in use for version-reporter so we can remove use of cosmos_key in our reports.

I already tf applied the service principals part of this PR from this branch, so that we can read the cosmos account and add those roles to it in the managed identity component

tests renovate report with removal of cosmos_key

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
