### PR TITLE
Remove all instances of COSMOS_KEY now MI setup works

### DIFF
--- a/reports/aksversions/Dockerfile
+++ b/reports/aksversions/Dockerfile
@@ -17,7 +17,6 @@ COPY . .
 
 ENV VAULT_NAME="" \
     SECRET_PATH="" \
-    COSMOS_KEY="" \
     COSMOS_DB_NAME="" \
     COSMOS_DB_CONTAINER="" \
     COSMOS_DB_URI=""

--- a/reports/aksversions/README.md
+++ b/reports/aksversions/README.md
@@ -58,7 +58,7 @@ Setting `SAVE_TO_COSMOS=False` will disable the interactions with Cosmos DB comp
 # Save documents to cosmos db
 if save_to_cosmos:
 # Establish connection to cosmos db
-    cosmosClient = CosmosClient(endpoint, credential=key)
+    cosmosClient = CosmosClient(endpoint, credential=credential)
 
 # Save documents to cosmos db
     try:

--- a/reports/aksversions/README.md
+++ b/reports/aksversions/README.md
@@ -32,7 +32,6 @@ The script utilises `DefaultAzureCredential` to access Azure.
 For access to Cosmos however you will need to set the following environment variables for a successful connection to be made. This values are looked up within `main.py`:
 
 - COSMOS_DB_URI
-- COSMOS_KEY
 
 These values can be found via the Azure Portal on the version reporter Cosmos DB instance.
 

--- a/reports/aksversions/main.py
+++ b/reports/aksversions/main.py
@@ -33,12 +33,11 @@ def main():
     # Define Environment variables for Cosmos
     if save_to_cosmos: 
         endpoint = os.getenv("COSMOS_DB_URI", None)
-        key = os.getenv("COSMOS_KEY", None)
         database = os.getenv("COSMOS_DB_NAME", "reports")
         container_name = os.getenv("COSMOS_DB_CONTAINER", "aksversions")
 
-        if not all([endpoint, key]):
-            logging.error("COSMOS_DB_URI and COSMOS_KEY environment variables must be set.")
+        if not all([endpoint]):
+            logging.error("COSMOS_DB_URI environment variables must be set.")
             return
 
     # Authenticate to Azure
@@ -139,7 +138,8 @@ def main():
     # Now we need to store them in CosmosDB and the aksversions container
     if save_to_cosmos:
         # Establish connection to cosmos db
-        cosmosClient = CosmosClient(endpoint, credential=key)
+        credential = DefaultAzureCredential()
+        cosmosClient = CosmosClient(endpoint, credential=credential)
 
         # Save documents to cosmos db
         try:

--- a/reports/aksversions/test_main.py
+++ b/reports/aksversions/test_main.py
@@ -1,6 +1,8 @@
 import pytest
 import os
 from unittest.mock import patch, MagicMock
+from azure.identity import DefaultAzureCredential
+
 from main import get_minor_version, main
 
 def test_get_minor_version():
@@ -14,10 +16,9 @@ def test_get_minor_version():
 def test_main_script(mock_cosmos_client, mock_container_service_client, mock_subscription_client, mock_default_credential):
 
     os.environ['COSMOS_DB_URI'] = 'URI'
-    os.environ['COSMOS_KEY'] = 'KEY'
 
     # Mock the Azure credential
-    mock_default_credential.return_value = MagicMock()
+    mock_default_credential.return_value = MagicMock()    
 
     # Mock the SubscriptionClient
     mock_subscription = MagicMock()
@@ -48,5 +49,5 @@ def test_main_script(mock_cosmos_client, mock_container_service_client, mock_sub
     mock_container_service_client.assert_called_once_with(mock_default_credential.return_value, mock_subscription_client.return_value.subscription_id)
     mock_container_service.managed_clusters.list.assert_called_once()
 
-    mock_cosmos_client.assert_called_once_with(os.environ['COSMOS_DB_URI'], credential=os.environ['COSMOS_KEY'])
+    mock_cosmos_client.assert_called_once_with(os.environ['COSMOS_DB_URI'], credential=mock_default_credential_instance)
     mock_cosmos.get_database_client.assert_called_once()

--- a/reports/docsoutdated/Dockerfile
+++ b/reports/docsoutdated/Dockerfile
@@ -16,7 +16,6 @@ COPY . .
 
 ENV VAULT_NAME="" \
     SECRET_PATH="" \
-    COSMOS_KEY="" \
     COSMOS_DB_NAME="" \
     COSMOS_DB_CONTAINER="" \
     COSMOS_DB_URI=""

--- a/reports/docsoutdated/main.py
+++ b/reports/docsoutdated/main.py
@@ -12,7 +12,6 @@ from azure.cosmos import CosmosClient, exceptions
 
 # Environment variables passed in via sds flux configuration
 endpoint = os.environ.get("COSMOS_DB_URI", None)
-key = os.environ.get("COSMOS_KEY", None)
 database = os.environ.get("COSMOS_DB_NAME", "reports")
 container_name = os.environ.get("COSMOS_DB_CONTAINER", "docsoutdated")
 
@@ -170,7 +169,8 @@ def build_report():
 
 try:
     print("Connection to database...")
-    client = CosmosClient(endpoint, key)
+    credential = DefaultAzureCredential()
+    client = CosmosClient(endpoint, credential=credential)
 
     print("Setting of connectivity to database")
     database = client.get_database_client(database)

--- a/reports/docsoutdated/requirements.txt
+++ b/reports/docsoutdated/requirements.txt
@@ -2,5 +2,6 @@ pytz
 pytest
 beautifulsoup4
 azure-cosmos>=4.4.0
+azure-identity==1.17.1
 requests
 datefinder

--- a/reports/helmcharts/Dockerfile
+++ b/reports/helmcharts/Dockerfile
@@ -19,7 +19,6 @@ COPY . .
 
 ENV VAULT_NAME="" \
     SECRET_PATH="" \
-    COSMOS_KEY="" \
     COSMOS_DB_NAME="reports" \
     COSMOS_DB_CONTAINER="helmcharts" \
     COSMOS_DB_URI="" \

--- a/reports/helmcharts/README.md
+++ b/reports/helmcharts/README.md
@@ -37,7 +37,6 @@ The Helm Charts reporting service uses two main scripts: `helm-chart-versions.sh
 You will need to set the following environment variables before the scripts can connect to Cosmos DB:
 
 - `COSMOS_DB_URI`
-- `COSMOS_KEY`
 
 Additionally, set the necessary environment variables for your cluster and environment:
 

--- a/reports/helmcharts/save-to-cosmos.py
+++ b/reports/helmcharts/save-to-cosmos.py
@@ -4,10 +4,10 @@ import json
 import pytz
 from datetime import datetime
 from azure.cosmos import CosmosClient, exceptions
+from azure.identity import DefaultAzureCredential
 
 # Environment variables passed in via sds flux configuration
 endpoint = os.environ.get("COSMOS_DB_URI", None)
-key = os.environ.get("COSMOS_KEY", None)
 database = os.environ.get("COSMOS_DB_NAME", "reports")
 container_name = os.environ.get("COSMOS_DB_CONTAINER", "helmcharts")
 environment = os.environ.get("ENVIRONMENT", None)
@@ -61,7 +61,8 @@ def get_formatted_datetime(strformat="%Y-%m-%d %H:%M:%S"):
 
 
 # Establish connection to cosmos db
-client = CosmosClient(endpoint, key)
+credential = DefaultAzureCredential()
+client = CosmosClient(endpoint, credential=credential)
 
 # Save document to cosmos db
 try:

--- a/reports/paloalto/Dockerfile
+++ b/reports/paloalto/Dockerfile
@@ -16,7 +16,6 @@ COPY . .
 
 ENV VAULT_NAME="" \
     SECRET_PATH="" \
-    COSMOS_KEY="" \
     COSMOS_DB_NAME="" \
     COSMOS_DB_CONTAINER="" \
     COSMOS_DB_URI="" \

--- a/reports/paloalto/storage_mgmt.py
+++ b/reports/paloalto/storage_mgmt.py
@@ -1,4 +1,5 @@
 from azure.cosmos import CosmosClient, exceptions
+from azure.identity import DefaultAzureCredential
 from utility import logger
 
 
@@ -6,7 +7,6 @@ class Storage:
 
     def __init__(self, config):
         self.db_uri = config.get("uri")
-        self.db_key = config.get("key")
         self.db_database = config.get("database")
         self.db_container = config.get("container")
         self.client = None
@@ -16,7 +16,8 @@ class Storage:
 
     def connect_to_db(self):
         logger("Establishing connection to cosmos db")
-        self.client = CosmosClient(self.db_uri, self.db_key)
+        credential = DefaultAzureCredential()
+        self.client = CosmosClient(self.db_uri, credential=credential)
         logger("Connection established")
 
     def save_document(self, document):

--- a/reports/paloalto/utility.py
+++ b/reports/paloalto/utility.py
@@ -54,7 +54,6 @@ def logger(message):
 def db_config():
     return {
         "uri": os.environ.get("COSMOS_DB_URI", None),
-        "key": os.environ.get("COSMOS_KEY", None),
         "database": os.environ.get("COSMOS_DB_NAME", "reports"),
         "container": os.environ.get("COSMOS_DB_CONTAINER", "paloalto"),
         "desired_version": os.environ.get("DESIRED_VERSION", None),

--- a/reports/platopsapps/Dockerfile
+++ b/reports/platopsapps/Dockerfile
@@ -16,7 +16,6 @@ COPY . .
 # SECRET PATH is used if a custom file path is used for those mounts (default: /mnt/secrets/)
 ENV VAULT_NAME="" \
     SECRET_PATH="" \
-    COSMOS_KEY="" \
     COSMOS_DB_NAME="" \
     COSMOS_DB_CONTAINER="" \
     COSMOS_DB_URI="" \

--- a/reports/platopsapps/README.md
+++ b/reports/platopsapps/README.md
@@ -47,7 +47,7 @@ Setting `SAVE_TO_COSMOS=False` will disable the interactions with Cosmos DB comp
 # Save documents to cosmos db
 if save_to_cosmos:
 # Establish connection to cosmos db
-    cosmosClient = CosmosClient(endpoint, credential=key)
+    cosmosClient = CosmosClient(endpoint, credential=credential)
 
 # Save documents to cosmos db
     try:

--- a/reports/platopsapps/README.md
+++ b/reports/platopsapps/README.md
@@ -28,7 +28,6 @@ As this report utilises Python you will need to have it installed, development w
 For access to Cosmos however you will need to set the following environment variables for a successful connection to be made. This values are looked up within `main.py`:
 
 - COSMOS_DB_URI
-- COSMOS_KEY
 
 These values can be found via the Azure Portal on the version reporter Cosmos DB instance.
 

--- a/reports/platopsapps/main.py
+++ b/reports/platopsapps/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from kubernetes import client, config
 from azure.cosmos import CosmosClient, exceptions
+from azure.identity import DefaultAzureCredential
 from cosmos_functions import remove_documents, add_documents
 from unittest.mock import patch, MagicMock
 from version_utility import flux_latest_version, camunda_latest_version, docmosis_latest_version, compare_versions, get_semvar
@@ -168,18 +169,19 @@ if __name__ == "__main__":
 
     if save_to_cosmos:
         endpoint = os.getenv("COSMOS_DB_URI", None)
-        key = os.getenv("COSMOS_KEY", None)
         database = os.getenv("COSMOS_DB_NAME", "reports")
         container_name = os.getenv("COSMOS_DB_CONTAINER", "platopsapps")
         
 
-        if not all([endpoint, key, database, container_name]):
-            logging.error("COSMOS_DB_URI, COSMOS_KEY, COSMOS_DB_NAME, and COSMOS_DB_CONTAINER environment variables must be set.")
+        if not all([endpoint, database, container_name]):
+            logging.error("COSMOS_DB_URI, COSMOS_DB_NAME, and COSMOS_DB_CONTAINER environment variables must be set.")
             sys.exit(1)
 
         # Save documents to cosmos db
         try:
-            cosmosClient = CosmosClient(endpoint, credential=key)
+            print("Setting of connectivity to database")
+            credential = DefaultAzureCredential()
+            cosmosClient = CosmosClient(endpoint, credential=credential)
             database = cosmosClient.get_database_client(database)
             db_container = database.get_container_client(container_name)
             remove_documents(db_container, environment)

--- a/reports/renovate/Dockerfile
+++ b/reports/renovate/Dockerfile
@@ -14,7 +14,6 @@ COPY . .
 
 ENV VAULT_NAME="" \
     SECRET_PATH="" \
-    COSMOS_KEY="" \
     COSMOS_DB_NAME="" \
     COSMOS_DB_CONTAINER="" \
     COSMOS_DB_URI="" \


### PR DESCRIPTION
Now setup to use DefaultAzureCredential, which on the cluster uses the service account -> managed identity -> resource route. Now we have given this MI access to DB, we don't need to specify a key anywhere anymore in our reports





<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
