### PR TITLE
Upgrade azurerm to latest

### DIFF
--- a/components/versionreporting/00-init.tf
+++ b/components/versionreporting/00-init.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = "4.9.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
Something using DTS Bootstrap service principals is still using old deprecated preview api versions when talking to aks...
This repo is talking to aks and has mention of those **and** is on old tf versions for azure