### PR TITLE
DTSPO-31756: Migrate to Workload Identity

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -41,6 +41,8 @@ variables:
     value: "DCD-CNP-Prod"
   - name: acrRepository
     value: "version-reporter-service"
+  - name: sds_ptl_mi_principal_id
+    value: ""
 
 resources:
   repositories:
@@ -125,8 +127,11 @@ parameters:
       - env: "stg"
         dependsOn: "sbox"
         serviceConnection: "DCD-CFTAPPS-STG"
-      - env: "ptl"
+      - env: "sdsptl"
         dependsOn: "ptlsbox"
+        serviceConnection: "DTS-SHAREDSERVICESPTL"
+      - env: "ptl"
+        dependsOn: "sdsptl"
         serviceConnection: "DTS-CFTPTL-INTSVC"
       - env: "prod"
         dependsOn: "stg"
@@ -198,6 +203,10 @@ stages:
           : - Managed_Identity_Infrastructure_${{ object.dependsOn }}
         - ${{ else }}:
           - Core_Infrastructure
+      ${{ if eq(object.env, 'ptl') }}:
+        variables:
+          - name: sds_ptl_mi_principal_id
+            value: $[ stageDependencies.Managed_Identity_Infrastructure_sdsptl.PlanAndApply.outputs['GetSDSMIPrincipalId.sds_ptl_mi_principal_id'] ]
       jobs:
         - job: PlanAndApply
           steps:
@@ -216,6 +225,23 @@ stages:
                 planCommandOptions: >-
                   -compact-warnings
                   -lock-timeout=30s
+                  -var "sds_ptl_mi_principal_id=$(sds_ptl_mi_principal_id)"
+            - ${{ if eq(object.env, 'sdsptl') }}:
+              - task: AzureCLI@2
+                name: GetSDSMIPrincipalId
+                displayName: 'Export SDS PTL MI principal ID'
+                condition: succeeded()
+                inputs:
+                  azureSubscription: ${{ object.serviceConnection }}
+                  scriptType: bash
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    principal_id=$(az identity show \
+                      --name monitoring-ptl-mi \
+                      --resource-group managed-identities-ptl-rg \
+                      --query principalId \
+                      --output tsv 2>/dev/null || echo "")
+                    echo "##vso[task.setvariable variable=sds_ptl_mi_principal_id;isOutput=true]$principal_id"
 
   - stage: "Reports"
     displayName: "Reports"

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -130,6 +130,7 @@ parameters:
       - env: "sdsptl"
         dependsOn: "ptlsbox"
         serviceConnection: "OPS-APPROVAL-GATE-PTL-ENVS"
+        backendResourceGroupName: "azure-control-ptl-rg"
       - env: "ptl"
         dependsOn: "sdsptl"
         serviceConnection: "DTS-CFTPTL-INTSVC"
@@ -219,6 +220,7 @@ stages:
                 environment:  ${{ object.env }}
                 component: "managedidentity"
                 terraformInitSubscription: ${{ variables.terraformInitSubscription }}
+                backendResourceGroupName: ${{ object.backendResourceGroupName }}
                 tfVarsFile: NULL
                 initCommandOptions: >-
                   -reconfigure

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -129,7 +129,7 @@ parameters:
         serviceConnection: "DCD-CFTAPPS-STG"
       - env: "sdsptl"
         dependsOn: "ptlsbox"
-        serviceConnection: "DTS-SHAREDSERVICESPTL"
+        serviceConnection: "OPS-APPROVAL-GATE-PTL-ENVS"
       - env: "ptl"
         dependsOn: "sdsptl"
         serviceConnection: "DTS-CFTPTL-INTSVC"

--- a/components/managedidentity/00-init.tf
+++ b/components/managedidentity/00-init.tf
@@ -19,7 +19,7 @@ provider "azurerm" {
 
 provider "azurerm" {
   alias                      = "managed_identity_infra_subs"
-  subscription_id            = local.mi_cft[local.mi_environment].subscription_id
+  subscription_id            = local.mi_cft[local.mi_subscription_key].subscription_id
   skip_provider_registration = "true"
   features {}
 }
@@ -39,3 +39,5 @@ provider "azurerm" {
   skip_provider_registration = "true"
   features {}
 }
+
+

--- a/components/managedidentity/02-variables.tf
+++ b/components/managedidentity/02-variables.tf
@@ -37,3 +37,9 @@ variable "sbox_metrics_cosmosdb" {
   type        = bool
   default     = false
 }
+
+variable "sds_ptl_mi_principal_id" {
+  description = "Principal ID of the SDS PTL managed identity. Set by the pipeline from the sdsptl stage output. When non-empty, role assignments for the SDS MI are created in this (ptl) run."
+  type        = string
+  default     = ""
+}

--- a/components/managedidentity/03-interpolated.tf
+++ b/components/managedidentity/03-interpolated.tf
@@ -10,7 +10,7 @@ locals {
 module "ctags" {
   source       = "github.com/hmcts/terraform-module-common-tags"
   builtFrom    = var.builtFrom
-  environment  = var.env
+  environment  = local.ctags_environment
   product      = var.product
   expiresAfter = var.expiresAfter
 }

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -66,16 +66,18 @@ resource "azurerm_cosmosdb_sql_role_assignment" "monitoring_mi_assignment" {
 }
 
 data "azurerm_storage_account" "finops" {
- provider            = azurerm.ptl
- name                = "finopsdataptlsa"
- resource_group_name = "finopsdataptlrg"
+  count               = var.env == "ptl" ? 1 : 0
+  provider            = azurerm.ptl
+  name                = "finopsdataptlsa"
+  resource_group_name = "finopsdataptlrg"
 }
 
 resource "azurerm_role_assignment" "version_reporter_storage" {
- provider             = azurerm.ptl
- scope                = data.azurerm_storage_account.finops.id
- role_definition_name = "Storage Blob Data Contributor"
- principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
+  count               = var.env == "ptl" ? 1 : 0
+  provider             = azurerm.ptl
+  scope                = data.azurerm_storage_account.finops.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
 }
 
 

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -75,7 +75,7 @@ data "azurerm_storage_account" "finops" {
 resource "azurerm_role_assignment" "version_reporter_storage" {
   count               = var.env == "ptl" ? 1 : 0
   provider             = azurerm.ptl
-  scope                = data.azurerm_storage_account.finops.id
+  scope                = data.azurerm_storage_account.finops[0].id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
 }

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -73,12 +73,78 @@ data "azurerm_storage_account" "finops" {
 }
 
 resource "azurerm_role_assignment" "version_reporter_storage" {
-  count               = var.env == "ptl" ? 1 : 0
+  count                = var.env == "ptl" ? 1 : 0
   provider             = azurerm.ptl
   scope                = data.azurerm_storage_account.finops[0].id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
 }
+
+# ---------------------------------------------------------------------------
+# SDS PTL MI role assignments
+# Managed from within the ptl run (DTS-CFTPTL-INTSVC) so that all role
+# assignments on CFT PTL resources are owned by a single service connection.
+# var.sds_ptl_mi_principal_id is exported by the sdsptl pipeline stage and
+# passed in as a tfvar — no cross-subscription read permissions required.
+# ---------------------------------------------------------------------------
+
+resource "azurerm_key_vault_access_policy" "sds_mi_access_policy" {
+  count        = var.sds_ptl_mi_principal_id != "" ? 1 : 0
+  provider     = azurerm.ptl
+  key_vault_id = data.azurerm_key_vault.ptl.id
+  object_id    = var.sds_ptl_mi_principal_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+
+  key_permissions = [
+    "Get",
+    "List",
+  ]
+
+  certificate_permissions = [
+    "Get",
+    "List",
+  ]
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}
+
+resource "azurerm_cosmosdb_sql_role_assignment" "sds_mi_version_reporter" {
+  count               = var.sds_ptl_mi_principal_id != "" ? 1 : 0
+  provider            = azurerm.ptl
+  resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.version_reporter.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = var.sds_ptl_mi_principal_id
+  scope               = data.azurerm_cosmosdb_account.version_reporter.id
+}
+
+resource "azurerm_cosmosdb_sql_role_assignment" "sds_mi_pipeline_metrics" {
+  count               = var.sds_ptl_mi_principal_id != "" ? 1 : 0
+  provider            = azurerm.pipeline-metrics
+  resource_group_name = data.azurerm_cosmosdb_account.pipeline_metrics.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.pipeline_metrics.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.pipeline_metrics.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = var.sds_ptl_mi_principal_id
+  scope               = data.azurerm_cosmosdb_account.pipeline_metrics.id
+}
+
+resource "azurerm_role_assignment" "sds_mi_storage" {
+  count                = var.sds_ptl_mi_principal_id != "" ? 1 : 0
+  provider             = azurerm.ptl
+  scope                = data.azurerm_storage_account.finops[0].id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.sds_ptl_mi_principal_id
+}
+
+
+
+
+
+
+
 
 
 # Service connection does not have enough access to grant this via automation

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -36,14 +36,12 @@ resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
 }
 
 data "azurerm_cosmosdb_account" "version_reporter" {
-  count               = var.env == "ptl" ? 1 : 0
   provider            = azurerm.ptl
   name                = "version-reporter-ptl-cosmos"
   resource_group_name = "cft-platform-version-reporter-ptl-rg"
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
-  count               = var.env == "ptl" ? 1 : 0
   provider            = azurerm.ptl
   resource_group_name = data.azurerm_cosmosdb_account.version_reporter[0].resource_group_name
   account_name        = data.azurerm_cosmosdb_account.version_reporter[0].name
@@ -66,6 +64,20 @@ resource "azurerm_cosmosdb_sql_role_assignment" "monitoring_mi_assignment" {
   principal_id        = azurerm_user_assigned_identity.managed_identity.principal_id
   scope               = data.azurerm_cosmosdb_account.pipeline_metrics.id
 }
+
+data "azurerm_storage_account" "finops" {
+ provider            = azurerm.ptl
+ name                = "finopsdataptlsa"
+ resource_group_name = "finopsdataptlrg"
+}
+
+resource "azurerm_role_assignment" "version_reporter_storage" {
+ provider             = azurerm.ptl
+ scope                = data.azurerm_storage_account.finops[0].id
+ role_definition_name = "Storage Blob Data Contributor"
+ principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
+}
+
 
 # Service connection does not have enough access to grant this via automation
 # The addition of the MI to the group has been completed manually and the code commented here to limit failures

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -139,14 +139,6 @@ resource "azurerm_role_assignment" "sds_mi_storage" {
   principal_id         = var.sds_ptl_mi_principal_id
 }
 
-
-
-
-
-
-
-
-
 # Service connection does not have enough access to grant this via automation
 # The addition of the MI to the group has been completed manually and the code commented here to limit failures
 # The code is being left here for reference and understand if required in future

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -1,3 +1,19 @@
+# Handles state rename from no-count to count to avoid destroy/recreate churn on existing CFT environments
+moved {
+  from = azurerm_key_vault_access_policy.managed_identity_access_policy
+  to   = azurerm_key_vault_access_policy.managed_identity_access_policy[0]
+}
+
+moved {
+  from = azurerm_cosmosdb_sql_role_assignment.identity_contributor
+  to   = azurerm_cosmosdb_sql_role_assignment.identity_contributor[0]
+}
+
+moved {
+  from = azurerm_cosmosdb_sql_role_assignment.monitoring_mi_assignment
+  to   = azurerm_cosmosdb_sql_role_assignment.monitoring_mi_assignment[0]
+}
+
 data "azurerm_resource_group" "managed_identities" {
   provider = azurerm.managed_identity_infra_subs
   name     = "managed-identities-${local.mi_environment}-rg"
@@ -14,6 +30,7 @@ resource "azurerm_user_assigned_identity" "managed_identity" {
 }
 
 resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
+  count        = var.env != "sdsptl" ? 1 : 0
   provider     = azurerm.ptl
   key_vault_id = data.azurerm_key_vault.ptl.id
   object_id    = azurerm_user_assigned_identity.managed_identity.principal_id
@@ -42,6 +59,7 @@ data "azurerm_cosmosdb_account" "version_reporter" {
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
+  count               = var.env != "sdsptl" ? 1 : 0
   provider            = azurerm.ptl
   resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
   account_name        = data.azurerm_cosmosdb_account.version_reporter.name
@@ -57,6 +75,7 @@ data "azurerm_cosmosdb_account" "pipeline_metrics" {
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "monitoring_mi_assignment" {
+  count               = var.env != "sdsptl" ? 1 : 0
   provider            = azurerm.pipeline-metrics
   resource_group_name = data.azurerm_cosmosdb_account.pipeline_metrics.resource_group_name
   account_name        = data.azurerm_cosmosdb_account.pipeline_metrics.name

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -36,19 +36,20 @@ resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
 }
 
 data "azurerm_cosmosdb_account" "version_reporter" {
+  count               = var.env == "ptl" ? 1 : 0
   provider            = azurerm.ptl
   name                = "version-reporter-ptl-cosmos"
   resource_group_name = "cft-platform-version-reporter-ptl-rg"
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
+  count               = var.env == "ptl" ? 1 : 0
   provider            = azurerm.ptl
-  resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
-  account_name        = data.azurerm_cosmosdb_account.version_reporter.name
-  # Cosmos DB Built-in Data Contributor
-  role_definition_id = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
-  principal_id       = azurerm_user_assigned_identity.managed_identity.principal_id
-  scope              = data.azurerm_cosmosdb_account.version_reporter.id
+  resource_group_name = data.azurerm_cosmosdb_account.version_reporter[0].resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.version_reporter[0].name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.version_reporter[0].id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = azurerm_user_assigned_identity.managed_identity.principal_id
+  scope               = data.azurerm_cosmosdb_account.version_reporter[0].id
 }
 
 data "azurerm_cosmosdb_account" "pipeline_metrics" {

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -43,11 +43,11 @@ data "azurerm_cosmosdb_account" "version_reporter" {
 
 resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
   provider            = azurerm.ptl
-  resource_group_name = data.azurerm_cosmosdb_account.version_reporter[0].resource_group_name
-  account_name        = data.azurerm_cosmosdb_account.version_reporter[0].name
-  role_definition_id  = "${data.azurerm_cosmosdb_account.version_reporter[0].id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.version_reporter.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
   principal_id        = azurerm_user_assigned_identity.managed_identity.principal_id
-  scope               = data.azurerm_cosmosdb_account.version_reporter[0].id
+  scope               = data.azurerm_cosmosdb_account.version_reporter.id
 }
 
 data "azurerm_cosmosdb_account" "pipeline_metrics" {

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -73,7 +73,7 @@ data "azurerm_storage_account" "finops" {
 
 resource "azurerm_role_assignment" "version_reporter_storage" {
  provider             = azurerm.ptl
- scope                = data.azurerm_storage_account.finops[0].id
+ scope                = data.azurerm_storage_account.finops.id
  role_definition_name = "Storage Blob Data Contributor"
  principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
 }

--- a/components/managedidentity/locals.tf
+++ b/components/managedidentity/locals.tf
@@ -1,5 +1,9 @@
 locals {
-  mi_environment = var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env == "sbox" ? "sandbox" : var.env == "stg" ? "aat" : var.env == "dev" ? "preview" : var.env == "test" ? "perftest" : var.env
+  # Resolves to the suffix used in resource group and MI names.
+  mi_environment = var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env == "sbox" ? "sandbox" : var.env == "stg" ? "aat" : var.env == "dev" ? "preview" : var.env == "test" ? "perftest" : var.env == "sdsptl" ? "ptl" : var.env
+  # Resolves to the key used for subscription ID lookup in mi_cft.
+  mi_subscription_key = var.env == "sdsptl" ? "sdsptl-intsvc" : local.mi_environment
+
   cosmosdb_name  = var.sbox_metrics_cosmosdb ? "sandbox-pipeline-metrics" : "pipeline-metrics"
   cosmosdb_rg    = var.sbox_metrics_cosmosdb ? "pipelinemetrics-database-sandbox" : "pipelinemetrics-database-prod"
   cosmosdb_env   = var.sbox_metrics_cosmosdb ? "sandbox" : "prod"
@@ -47,6 +51,10 @@ locals {
     # DTS-CFTPTL-INTSVC
     cftptl-intsvc = {
       subscription_id = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+    }
+    # DTS-SHAREDSERVICESPTL
+    sdsptl-intsvc = {
+      subscription_id = "6c4d2513-a873-41b4-afdd-b05a33206631"
     }
   }
 }

--- a/components/managedidentity/locals.tf
+++ b/components/managedidentity/locals.tf
@@ -4,6 +4,10 @@ locals {
   # Resolves to the key used for subscription ID lookup in mi_cft.
   mi_subscription_key = var.env == "sdsptl" ? "sdsptl-intsvc" : local.mi_environment
 
+  # Resolves to a valid environment value for the common-tags module.
+  # sdsptl is not a known environment in the module's maps, so map it to ptl.
+  ctags_environment = var.env == "sdsptl" ? "ptl" : var.env
+
   cosmosdb_name = var.sbox_metrics_cosmosdb ? "sandbox-pipeline-metrics" : "pipeline-metrics"
   cosmosdb_rg   = var.sbox_metrics_cosmosdb ? "pipelinemetrics-database-sandbox" : "pipelinemetrics-database-prod"
   cosmosdb_env  = var.sbox_metrics_cosmosdb ? "sandbox" : "prod"

--- a/components/managedidentity/locals.tf
+++ b/components/managedidentity/locals.tf
@@ -4,9 +4,9 @@ locals {
   # Resolves to the key used for subscription ID lookup in mi_cft.
   mi_subscription_key = var.env == "sdsptl" ? "sdsptl-intsvc" : local.mi_environment
 
-  cosmosdb_name  = var.sbox_metrics_cosmosdb ? "sandbox-pipeline-metrics" : "pipeline-metrics"
-  cosmosdb_rg    = var.sbox_metrics_cosmosdb ? "pipelinemetrics-database-sandbox" : "pipelinemetrics-database-prod"
-  cosmosdb_env   = var.sbox_metrics_cosmosdb ? "sandbox" : "prod"
+  cosmosdb_name = var.sbox_metrics_cosmosdb ? "sandbox-pipeline-metrics" : "pipeline-metrics"
+  cosmosdb_rg   = var.sbox_metrics_cosmosdb ? "pipelinemetrics-database-sandbox" : "pipelinemetrics-database-prod"
+  cosmosdb_env  = var.sbox_metrics_cosmosdb ? "sandbox" : "prod"
 
   cosmos_account = {
     sandbox = {

--- a/reports/cveinfo/save_to_db.py
+++ b/reports/cveinfo/save_to_db.py
@@ -10,7 +10,6 @@ from azure.identity.aio import DefaultAzureCredential
 
 # Environment variables passed in via sds flux configuration
 endpoint = os.getenv("COSMOS_DB_URI")
-key = os.getenv("COSMOS_KEY")
 database_name = os.getenv("COSMOS_DB_NAME", "reports")
 container_name = os.getenv("COSMOS_DB_CONTAINER", "cveinfo")
 

--- a/reports/cveinfo/save_to_db.py
+++ b/reports/cveinfo/save_to_db.py
@@ -6,6 +6,7 @@ import logging
 
 from azure.cosmos import exceptions
 from azure.cosmos.aio import CosmosClient
+from azure.identity.aio import DefaultAzureCredential
 
 # Environment variables passed in via sds flux configuration
 endpoint = os.getenv("COSMOS_DB_URI")
@@ -25,7 +26,7 @@ def get_formatted_time():
 
 async def add_batch(batch):
     try:
-        async with CosmosClient(url=endpoint, credential=key) as client:
+        async with CosmosClient(url=endpoint, credential=DefaultAzureCredential()) as client:
             database = client.get_database_client(database_name)
             container = database.get_container_client(container_name)
 

--- a/reports/docsoutdated/main.py
+++ b/reports/docsoutdated/main.py
@@ -9,6 +9,7 @@ from datetime import date
 from datetime import datetime
 from urllib.parse import urljoin
 from azure.cosmos import CosmosClient, exceptions
+from azure.identity import DefaultAzureCredential
 
 # Environment variables passed in via sds flux configuration
 endpoint = os.environ.get("COSMOS_DB_URI", None)

--- a/reports/hourlyusage/storage.py
+++ b/reports/hourlyusage/storage.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 from azure.storage.blob import BlobServiceClient
+from azure.identity import DefaultAzureCredential
 from utility import get_headers_file
 
 
@@ -13,9 +14,8 @@ class Storage:
     def __init__(self):
         self.account_url = os.getenv("AZURE_STORAGE_URL")
         self.container_name = os.getenv("AZURE_STORAGE_CONTAINER")
-        self.shared_access_key = os.getenv("AZURE_STORAGE_ACCESS_KEY")
-        self.blob_service_client = BlobServiceClient(self.account_url, credential=self.shared_access_key)
-        print("Authentication with access key successful")
+        self.blob_service_client = BlobServiceClient(self.account_url, credential=DefaultAzureCredential())
+        print("Authentication with workload identity successful")
 
     def get_blob_service_client(self):
         return self.blob_service_client


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31756

### Change description

- Current deployment of version-reporter-services is dependant on Client ID of App Reg, Cosmos DB Key & Storage Account Key
- To avoid manual updating of Client ID on 3-month expiry and to follow best practice, migrating to Workload Identity
- Alter python code to remove explicit key handling and use DefaultAzureCredential for compatiblity with Workload Identity
- Add new SDS PTL Monitoring MI and role assignments. There's a bit of a workaround here to avoid any cross-subscription rights where I'm outputing the principal ID of the SDS PTL monitoring MI, this then gets reabsorbed via DevOps env var to the CFT PTL env run
- Workaround means no data lookup is needed for CFT PTL run for SDS PTL moniting MI, removing any permission requirement - this does couple SDS & CFT PTL together as CFT PTL env run is assigning SDS MI role assignments but as both the Cosmos DB & Storage Account are CFT PTL only this is the cleanest, least permissive method to achieve role assignments needed.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
