### PR TITLE
DTSPO-31756: remove sds mi and non-hourlyreport changes

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -41,8 +41,6 @@ variables:
     value: "DCD-CNP-Prod"
   - name: acrRepository
     value: "version-reporter-service"
-  - name: sds_ptl_mi_principal_id
-    value: ""
 
 resources:
   repositories:
@@ -127,12 +125,8 @@ parameters:
       - env: "stg"
         dependsOn: "sbox"
         serviceConnection: "DCD-CFTAPPS-STG"
-      - env: "sdsptl"
-        dependsOn: "ptlsbox"
-        serviceConnection: "OPS-APPROVAL-GATE-PTL-ENVS"
-        backendResourceGroupName: "azure-control-ptl-rg"
       - env: "ptl"
-        dependsOn: "sdsptl"
+        dependsOn: "ptlsbox"
         serviceConnection: "DTS-CFTPTL-INTSVC"
       - env: "prod"
         dependsOn: "stg"
@@ -204,10 +198,6 @@ stages:
           : - Managed_Identity_Infrastructure_${{ object.dependsOn }}
         - ${{ else }}:
           - Core_Infrastructure
-      ${{ if eq(object.env, 'ptl') }}:
-        variables:
-          - name: sds_ptl_mi_principal_id
-            value: $[ stageDependencies.Managed_Identity_Infrastructure_sdsptl.PlanAndApply.outputs['GetSDSMIPrincipalId.sds_ptl_mi_principal_id'] ]
       jobs:
         - job: PlanAndApply
           steps:
@@ -220,30 +210,12 @@ stages:
                 environment:  ${{ object.env }}
                 component: "managedidentity"
                 terraformInitSubscription: ${{ variables.terraformInitSubscription }}
-                backendResourceGroupName: ${{ object.backendResourceGroupName }}
                 tfVarsFile: NULL
                 initCommandOptions: >-
                   -reconfigure
                 planCommandOptions: >-
                   -compact-warnings
                   -lock-timeout=30s
-                  -var "sds_ptl_mi_principal_id=$(sds_ptl_mi_principal_id)"
-            - ${{ if eq(object.env, 'sdsptl') }}:
-              - task: AzureCLI@2
-                name: GetSDSMIPrincipalId
-                displayName: 'Export SDS PTL MI principal ID'
-                condition: succeeded()
-                inputs:
-                  azureSubscription: ${{ object.serviceConnection }}
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    principal_id=$(az identity show \
-                      --name monitoring-ptl-mi \
-                      --resource-group managed-identities-ptl-rg \
-                      --query principalId \
-                      --output tsv 2>/dev/null || echo "")
-                    echo "##vso[task.setvariable variable=sds_ptl_mi_principal_id;isOutput=true]$principal_id"
 
   - stage: "Reports"
     displayName: "Reports"

--- a/components/managedidentity/00-init.tf
+++ b/components/managedidentity/00-init.tf
@@ -19,7 +19,7 @@ provider "azurerm" {
 
 provider "azurerm" {
   alias                      = "managed_identity_infra_subs"
-  subscription_id            = local.mi_cft[local.mi_subscription_key].subscription_id
+  subscription_id            = local.mi_cft[local.mi_environment].subscription_id
   skip_provider_registration = "true"
   features {}
 }

--- a/components/managedidentity/02-variables.tf
+++ b/components/managedidentity/02-variables.tf
@@ -37,9 +37,3 @@ variable "sbox_metrics_cosmosdb" {
   type        = bool
   default     = false
 }
-
-variable "sds_ptl_mi_principal_id" {
-  description = "Principal ID of the SDS PTL managed identity. Set by the pipeline from the sdsptl stage output. When non-empty, role assignments for the SDS MI are created in this (ptl) run."
-  type        = string
-  default     = ""
-}

--- a/components/managedidentity/03-interpolated.tf
+++ b/components/managedidentity/03-interpolated.tf
@@ -10,7 +10,7 @@ locals {
 module "ctags" {
   source       = "github.com/hmcts/terraform-module-common-tags"
   builtFrom    = var.builtFrom
-  environment  = local.ctags_environment
+  environment  = var.env
   product      = var.product
   expiresAfter = var.expiresAfter
 }

--- a/components/managedidentity/04-managed-identities.tf
+++ b/components/managedidentity/04-managed-identities.tf
@@ -1,3 +1,18 @@
+moved {
+  from = azurerm_key_vault_access_policy.managed_identity_access_policy[0]
+  to   = azurerm_key_vault_access_policy.managed_identity_access_policy
+}
+
+moved {
+  from = azurerm_cosmosdb_sql_role_assignment.identity_contributor[0]
+  to   = azurerm_cosmosdb_sql_role_assignment.identity_contributor
+}
+
+moved {
+  from = azurerm_cosmosdb_sql_role_assignment.monitoring_mi_assignment[0]
+  to   = azurerm_cosmosdb_sql_role_assignment.monitoring_mi_assignment
+}
+
 data "azurerm_resource_group" "managed_identities" {
   provider = azurerm.managed_identity_infra_subs
   name     = "managed-identities-${local.mi_environment}-rg"
@@ -14,7 +29,6 @@ resource "azurerm_user_assigned_identity" "managed_identity" {
 }
 
 resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
-  count        = var.env != "sdsptl" ? 1 : 0
   provider     = azurerm.ptl
   key_vault_id = data.azurerm_key_vault.ptl.id
   object_id    = azurerm_user_assigned_identity.managed_identity.principal_id
@@ -43,7 +57,6 @@ data "azurerm_cosmosdb_account" "version_reporter" {
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "identity_contributor" {
-  count               = var.env != "sdsptl" ? 1 : 0
   provider            = azurerm.ptl
   resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
   account_name        = data.azurerm_cosmosdb_account.version_reporter.name
@@ -59,7 +72,6 @@ data "azurerm_cosmosdb_account" "pipeline_metrics" {
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "monitoring_mi_assignment" {
-  count               = var.env != "sdsptl" ? 1 : 0
   provider            = azurerm.pipeline-metrics
   resource_group_name = data.azurerm_cosmosdb_account.pipeline_metrics.resource_group_name
   account_name        = data.azurerm_cosmosdb_account.pipeline_metrics.name
@@ -81,65 +93,6 @@ resource "azurerm_role_assignment" "version_reporter_storage" {
   scope                = data.azurerm_storage_account.finops[0].id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
-}
-
-# ---------------------------------------------------------------------------
-# SDS PTL MI role assignments
-# Managed from within the ptl run (DTS-CFTPTL-INTSVC) so that all role
-# assignments on CFT PTL resources are owned by a single service connection.
-# var.sds_ptl_mi_principal_id is exported by the sdsptl pipeline stage and
-# passed in as a tfvar — no cross-subscription read permissions required.
-# ---------------------------------------------------------------------------
-
-resource "azurerm_key_vault_access_policy" "sds_mi_access_policy" {
-  count        = var.sds_ptl_mi_principal_id != "" ? 1 : 0
-  provider     = azurerm.ptl
-  key_vault_id = data.azurerm_key_vault.ptl.id
-  object_id    = var.sds_ptl_mi_principal_id
-  tenant_id    = data.azurerm_client_config.current.tenant_id
-
-  key_permissions = [
-    "Get",
-    "List",
-  ]
-
-  certificate_permissions = [
-    "Get",
-    "List",
-  ]
-
-  secret_permissions = [
-    "Get",
-    "List",
-  ]
-}
-
-resource "azurerm_cosmosdb_sql_role_assignment" "sds_mi_version_reporter" {
-  count               = var.sds_ptl_mi_principal_id != "" ? 1 : 0
-  provider            = azurerm.ptl
-  resource_group_name = data.azurerm_cosmosdb_account.version_reporter.resource_group_name
-  account_name        = data.azurerm_cosmosdb_account.version_reporter.name
-  role_definition_id  = "${data.azurerm_cosmosdb_account.version_reporter.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
-  principal_id        = var.sds_ptl_mi_principal_id
-  scope               = data.azurerm_cosmosdb_account.version_reporter.id
-}
-
-resource "azurerm_cosmosdb_sql_role_assignment" "sds_mi_pipeline_metrics" {
-  count               = var.sds_ptl_mi_principal_id != "" ? 1 : 0
-  provider            = azurerm.pipeline-metrics
-  resource_group_name = data.azurerm_cosmosdb_account.pipeline_metrics.resource_group_name
-  account_name        = data.azurerm_cosmosdb_account.pipeline_metrics.name
-  role_definition_id  = "${data.azurerm_cosmosdb_account.pipeline_metrics.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
-  principal_id        = var.sds_ptl_mi_principal_id
-  scope               = data.azurerm_cosmosdb_account.pipeline_metrics.id
-}
-
-resource "azurerm_role_assignment" "sds_mi_storage" {
-  count                = var.sds_ptl_mi_principal_id != "" ? 1 : 0
-  provider             = azurerm.ptl
-  scope                = data.azurerm_storage_account.finops[0].id
-  role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = var.sds_ptl_mi_principal_id
 }
 
 # Service connection does not have enough access to grant this via automation

--- a/components/managedidentity/locals.tf
+++ b/components/managedidentity/locals.tf
@@ -1,12 +1,6 @@
 locals {
   # Resolves to the suffix used in resource group and MI names.
-  mi_environment = var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env == "sbox" ? "sandbox" : var.env == "stg" ? "aat" : var.env == "dev" ? "preview" : var.env == "test" ? "perftest" : var.env == "sdsptl" ? "ptl" : var.env
-  # Resolves to the key used for subscription ID lookup in mi_cft.
-  mi_subscription_key = var.env == "sdsptl" ? "sdsptl-intsvc" : local.mi_environment
-
-  # Resolves to a valid environment value for the common-tags module.
-  # sdsptl is not a known environment in the module's maps, so map it to ptl.
-  ctags_environment = var.env == "sdsptl" ? "ptl" : var.env
+  mi_environment = var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env == "sbox" ? "sandbox" : var.env == "stg" ? "aat" : var.env == "dev" ? "preview" : var.env == "test" ? "perftest" : var.env
 
   cosmosdb_name = var.sbox_metrics_cosmosdb ? "sandbox-pipeline-metrics" : "pipeline-metrics"
   cosmosdb_rg   = var.sbox_metrics_cosmosdb ? "pipelinemetrics-database-sandbox" : "pipelinemetrics-database-prod"
@@ -55,10 +49,6 @@ locals {
     # DTS-CFTPTL-INTSVC
     cftptl-intsvc = {
       subscription_id = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-    }
-    # DTS-SHAREDSERVICESPTL
-    sdsptl-intsvc = {
-      subscription_id = "6c4d2513-a873-41b4-afdd-b05a33206631"
     }
   }
 }

--- a/reports/cveinfo/save_to_db.py
+++ b/reports/cveinfo/save_to_db.py
@@ -6,10 +6,10 @@ import logging
 
 from azure.cosmos import exceptions
 from azure.cosmos.aio import CosmosClient
-from azure.identity.aio import DefaultAzureCredential
 
 # Environment variables passed in via sds flux configuration
 endpoint = os.getenv("COSMOS_DB_URI")
+key = os.getenv("COSMOS_KEY")
 database_name = os.getenv("COSMOS_DB_NAME", "reports")
 container_name = os.getenv("COSMOS_DB_CONTAINER", "cveinfo")
 
@@ -25,7 +25,7 @@ def get_formatted_time():
 
 async def add_batch(batch):
     try:
-        async with CosmosClient(url=endpoint, credential=DefaultAzureCredential()) as client:
+        async with CosmosClient(url=endpoint, credential=key) as client:
             database = client.get_database_client(database_name)
             container = database.get_container_client(container_name)
 

--- a/reports/docsoutdated/main.py
+++ b/reports/docsoutdated/main.py
@@ -9,7 +9,6 @@ from datetime import date
 from datetime import datetime
 from urllib.parse import urljoin
 from azure.cosmos import CosmosClient, exceptions
-from azure.identity import DefaultAzureCredential
 
 # Environment variables passed in via sds flux configuration
 endpoint = os.environ.get("COSMOS_DB_URI", None)


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31756

### Change description

- The correct place for this to run is CFT PTL
- Remove the code changes allowing for the move from SDS Prod to SDS PTL, in favour of CFT PTL redeployment
- Remove DefaultAzureCredential for platopsapps and helmcharts as these run individually on each cluster - technically its possible to use RBAC on MI but would require more extrapolation of the workaround being reverted here for each non-PTL env and code complexity isn't worth the gain of key auth removal

## Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
